### PR TITLE
relaunch recognition in case of error

### DIFF
--- a/src/android/com/pbakondy/SpeechRecognition.java
+++ b/src/android/com/pbakondy/SpeechRecognition.java
@@ -274,6 +274,10 @@ public class SpeechRecognition extends CordovaPlugin {
     public void onError(int errorCode) {
       String errorMessage = getErrorText(errorCode);
       Log.d(LOG_TAG, "Error: " + errorMessage);
+      recognizer.stopListening();
+      recognizer.cancel();
+      recognizer.destroy();
+      recognizer.startListening();
       callbackContext.error(errorMessage);
     }
 


### PR DESCRIPTION
To avoid to have the recognizer always broken after a another call sending an error, better to clean it and start it fresh for the next calls