### PR TITLE
Fixes #23 

### DIFF
--- a/src/ios/SpeechRecognition.m
+++ b/src/ios/SpeechRecognition.m
@@ -81,8 +81,8 @@
         }
 
         AVAudioSession *audioSession = [AVAudioSession sharedInstance];
-        [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
-        [audioSession setMode:AVAudioSessionModeMeasurement error:nil];
+        [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker error:nil];
+        [audioSession setMode:AVAudioSessionModeDefault error:nil];
         [audioSession setActive:YES withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:nil];
 
         self.recognitionRequest = [[SFSpeechAudioBufferRecognitionRequest alloc] init];


### PR DESCRIPTION
This PR fixes issue #23 by making speaker of the device to be used by default or headphones when plugged. This issues only appears on iPhones because it has "ear speaker" thus audio output is sent to ear speaker instead of main speaker. 
Creating the "low volume" as creator of the issue pointed out.